### PR TITLE
Launches program in 5.4 instead of 5.3

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -2,9 +2,9 @@
   "version": "1.0",
   "components": [
     "Microsoft.Net.Component.4.6.2.TargetingPack",
-    "Microsoft.VisualStudio.Component.VC.14.36.17.6.x86.x64",
+    "Microsoft.VisualStudio.Component.VC.14.38.17.8.x86.x64",
     "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-    "Microsoft.VisualStudio.Component.Windows10SDK.22000",
+    "Microsoft.VisualStudio.Component.Windows10SDK.22621",
     "Microsoft.VisualStudio.Workload.CoreEditor",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Workload.NativeDesktop",

--- a/WalkingHorror.uproject
+++ b/WalkingHorror.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "5.3",
+	"EngineAssociation": "5.4",
 	"Category": "",
 	"Description": "",
 	"Modules": [


### PR DESCRIPTION
To use this, you should already have 5.4 version of Unreal in your system.

Right click the uproject file and generate visual studio files and then launch